### PR TITLE
Fix typo that stops the bot from work

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const mod = require('revcjatapi');
+const mod = require('revchatapi');
 const revolt = ""; // Revolt Bot Token
 const discord = ""; // Discord Bot Token
 const revChannels = []; // Revolt channels


### PR DESCRIPTION
The first line of `index.js` had a typo not work, I have changed it and now it works when you put the token and channels IDs in